### PR TITLE
[WIP] Add pan event support

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,12 +36,13 @@
     "@opam/js_of_ocaml-lwt": "^3.3.0",
     "@opam/lwt": "^4.0.0",
     "@opam/lwt_ppx": "^1.1.0",
-    "esy-sdl2": "^2.0.10004",
+    "esy-sdl2": "*",
     "esy-cmake": "^0.3.4",
     "reason-gl-matrix": "^0.9.9304"
   },
   "resolutions": {
-    "@opam/cmdliner": "1.0.2"
+    "@opam/cmdliner": "1.0.2",
+    "esy-sdl2": "link:../esy-sdl2"
   },
   "devDependencies": {
     "ocaml": ">=4.6.0 <4.9.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reason-sdl2",
-  "version": "2.10.3006",
+  "version": "2.10.3007",
   "description": "SDL2 bindings for OCaml",
   "license": "MIT",
   "scripts": {

--- a/src/sdl2.re
+++ b/src/sdl2.re
@@ -9,6 +9,12 @@ module Size = {
   };
 };
 
+module ScreenSaver = {
+  external enable: unit => unit = "resdl_SDL_EnableScreenSaver";
+  external disable: unit => unit = "resdl_SDL_DisableScreenSaver";
+  external isEnabled: unit => bool = "resdl_SDL_IsScreenSaverEnabled";
+};
+
 module Surface = {
   type t;
   external createFromImagePath: string => result(t, string) =

--- a/src/sdl2.re
+++ b/src/sdl2.re
@@ -411,8 +411,15 @@ module Event = {
         deltaY,
         isFlipped ? 1 : 0,
       )
-    | Pan =>
-        Printf.sprintf("Pan event")
+    | MousePan({windowID, deltaX, deltaY, containsX, containsY, isFling, isInterrupt, _}) =>
+      Printf.sprintf("Pan event: %d %d %d %d %d %d %d",
+                     windowID,
+                     deltaX,
+                     deltaY,
+                     if(containsX) 1 else 0,
+                     if(containsY) 1 else 0,
+                     if(isFling) 1 else 0,
+                     if(isInterrupt) 1 else 0)
     | MouseButtonUp({windowID, button, _}) =>
       Printf.sprintf(
         "MouseButtonUp windowId: %d button: %s",

--- a/src/sdl2.re
+++ b/src/sdl2.re
@@ -237,6 +237,18 @@ module Keycode = {
   let left = 1073741904;
 };
 
+module WheelType = {
+    type t =
+      | Last
+      | Undefined
+      | Touchscreen
+      | Touchpad
+      | Wheel
+      | WheelPrecise
+      | OtherNonKinetic
+      | OtherKinetic;
+}
+
 module Keymod = {
   type t = int;
 
@@ -302,6 +314,17 @@ module Event = {
     deltaY: int,
     isFlipped: bool,
   };
+
+  type mousePan = {
+    windowID: int,
+    deltaX: int,
+    deltaY: int,
+    containsX: bool,
+    containsY: bool,
+    isFling: bool,
+    isInterrupt: bool,
+    source: WheelType.t,
+  }
 
   type mouseButtonEvent = {
     windowID: int,
@@ -371,6 +394,7 @@ module Event = {
     | WindowClosed(windowEvent)
     | WindowTakeFocus(windowEvent)
     | WindowHitTest(windowEvent)
+    | MousePan(mousePan)
     // An event that hasn't been implemented yet
     | Unknown;
 
@@ -387,6 +411,8 @@ module Event = {
         deltaY,
         isFlipped ? 1 : 0,
       )
+    | Pan =>
+        Printf.sprintf("Pan event")
     | MouseButtonUp({windowID, button, _}) =>
       Printf.sprintf(
         "MouseButtonUp windowId: %d button: %s",

--- a/src/sdl2.re
+++ b/src/sdl2.re
@@ -476,6 +476,7 @@ module Event = {
   };
 
   external poll: unit => option(t) = "resdl_SDL_PollEvent";
+  external push: unit => unit = "resdl_SDL_PushEvent";
   external wait: unit => result(t, string) = "resdl_SDL_WaitEvent";
   external waitTimeout: int => option(t) = "resdl_SDL_WaitTimeoutEvent";
 };

--- a/src/sdl2_stubs.js
+++ b/src/sdl2_stubs.js
@@ -122,6 +122,21 @@ function resdl_SDL_CreateSystemCursor(shape) {
   }
 }
 
+// Provides: resdl_SDL_EnableScreenSaver
+function resdl_SDL_EnableScreenSaver() {
+  // no op
+}
+
+// Provides: resdl_SDL_DisableScreenSaver
+function resdl_SDL_DisableScreenSaver() {
+  // no op
+}
+
+// Provides: resdl_SDL_IsScreenSaverEnabled
+function resdl_SDL_IsScreenSaverEnabled() {
+  return false;
+}
+
 // Provides: resdl_SDL_GL_SetSwapInterval
 function resdl_SDL_GL_SetSwapInterval() {
   // no op

--- a/src/sdl2_stubs.js
+++ b/src/sdl2_stubs.js
@@ -142,6 +142,11 @@ function resdl_SDL_GL_SetSwapInterval() {
   // no op
 }
 
+// Provides: resdl_SDL_PushEvent
+function resdl_SDL_PushEvent() {
+  // no op
+}
+
 // Provides: resdl_SDL_GL_MakeCurrent
 function resdl_SDL_GL_MakeCurrent() {
   // no op

--- a/src/sdl2_wrapper.cpp
+++ b/src/sdl2_wrapper.cpp
@@ -45,6 +45,24 @@ static value Val_error(value v) {
 }
 
 extern "C" {
+CAMLprim value resdl_SDL_EnableScreenSaver() {
+  CAMLparam0();
+  SDL_EnableScreenSaver();
+  CAMLreturn(Val_unit);
+}
+
+CAMLprim value resdl_SDL_DisableScreenSaver() {
+  CAMLparam0();
+  SDL_DisableScreenSaver();
+  CAMLreturn(Val_unit);
+}
+
+CAMLprim value resdl_SDL_IsScreenSaverEnabled() {
+  CAMLparam0();
+  int result = SDL_IsScreenSaverEnabled() == SDL_TRUE;
+  CAMLreturn(Val_int(result));
+}
+
 CAMLprim value resdl_SDL_SetMainReady() {
   SDL_SetMainReady();
 

--- a/src/sdl2_wrapper.cpp
+++ b/src/sdl2_wrapper.cpp
@@ -742,7 +742,9 @@ CAMLprim value resdl_SDL_CreateRGBSurfaceFromImage(value vPath) {
 
 CAMLprim value resdl_SDL_GL_SwapWindow(value w) {
   SDL_Window *win = (SDL_Window *)w;
+  caml_release_runtime_system();
   SDL_GL_SwapWindow(win);
+  caml_acquire_runtime_system();
   return Val_unit;
 }
 

--- a/src/sdl2_wrapper.cpp
+++ b/src/sdl2_wrapper.cpp
@@ -564,6 +564,16 @@ CAMLprim value resdl_SDL_WaitEvent() {
   CAMLreturn(ret);
 }
 
+CAMLprim value resdl_SDL_PushEvent() {
+  CAMLparam0();
+
+  SDL_Event user_event;
+  user_event.type = SDL_USEREVENT;
+  SDL_PushEvent(&user_event);
+
+  CAMLreturn(Val_unit);
+};
+
 CAMLprim value resdl_SDL_WaitTimeoutEvent(value vTimeout) {
   CAMLparam1(vTimeout);
   CAMLlocal2(ret, evt);

--- a/src/sdl2_wrapper.cpp
+++ b/src/sdl2_wrapper.cpp
@@ -365,6 +365,8 @@ CAMLprim value Val_SDL_Event(SDL_Event *event) {
 
   int tag, mouseButton;
 
+  printf("event type is %d while pan event type is %d and mousewheel is %d\n", event->type, SDL_PANEVENT, SDL_MOUSEWHEEL);
+
   switch (event->type) {
   case SDL_QUIT:
     v = Val_int(0);
@@ -461,6 +463,24 @@ CAMLprim value Val_SDL_Event(SDL_Event *event) {
 
     Store_field(v, 0, vInner);
     break;
+  case SDL_PANEVENT:
+    printf("dispatches pan event from wrapper\n");
+    v = caml_alloc(1, 24);
+
+    vInner = caml_alloc(8, 0);
+    Store_field(vInner, 0, Val_int(event->window.windowID));
+    Store_field(vInner, 1, Val_int(event->pan.x));
+    Store_field(vInner, 2, Val_int(event->pan.y));
+    Store_field(vInner, 3, Val_bool(event->pan.contains_x));
+    Store_field(vInner, 4, Val_bool(event->pan.contains_y));
+    Store_field(vInner, 5, Val_bool(event->pan.fling));
+    Store_field(vInner, 6, Val_bool(event->pan.interrupt));
+    // verify this is the correct way of representing a ref to some WheelType.t
+    Store_field(vInner, 7, Val_int(event->pan.source_type));
+
+    Store_field(v, 0, vInner);
+    printf("stored fields\n");
+    break;
   case SDL_WINDOWEVENT:
     switch (event->window.event) {
     case SDL_WINDOWEVENT_SHOWN:
@@ -514,21 +534,8 @@ CAMLprim value Val_SDL_Event(SDL_Event *event) {
     case SDL_WINDOWEVENT_HIT_TEST:
       v = Val_SDL_WindowEvent(23, event->window.windowID);
       break;
-    case SDL_PANEVENT:
-      v = caml_alloc(1, 24);
-
-      vInner = caml_alloc(8, 0);
-      Store_field(vInner, 0, Val_int(event->window.windowID));
-      Store_field(vInner, 1, Val_int(event->pan.x));
-      Store_field(vInner, 2, Val_int(event->pan.y));
-      Store_field(vInner, 3, Val_bool(event->pan.contains_x));
-      Store_field(vInner, 4, Val_bool(event->pan.contains_y));
-      Store_field(vInner, 5, Val_bool(event->pan.fling));
-      Store_field(vInner, 6, Val_bool(event->pan.interrupt));
-      // verify this is the correct way of representing a ref to some WheelType.t
-      Store_field(vInner, 7, Val_int(event->pan.source_type));
-      break;
     default:
+      printf("Unknown event in sdl2_wrapper, event enum code was %d\n", event->type);
       v = Val_int(1);
     };
 

--- a/src/sdl2_wrapper.cpp
+++ b/src/sdl2_wrapper.cpp
@@ -56,57 +56,55 @@ CAMLprim value resdl_SDL_DestroyWindow(value vWin) {
   return Val_unit;
 }
 
-SDL_HitTestResult resdl_hit_test(
-  SDL_Window *win,
-  const SDL_Point *area,
-  void *data) {
+SDL_HitTestResult resdl_hit_test(SDL_Window *win, const SDL_Point *area,
+                                 void *data) {
 
-    static value *hitTestCallback = NULL;
-    if (hitTestCallback == NULL) {
-      hitTestCallback = caml_named_value("__sdl2_caml_hittest__");
-    }
-    value vWin = (value)win;
-    value vRet = caml_callback3(*hitTestCallback, vWin, Val_int(area->x), Val_int(area->y));
-    SDL_HitTestResult result;
-    switch (Int_val(vRet)) {
-      case 0:
-        result = SDL_HITTEST_NORMAL;
-        break;
-      case 1:
-        result = SDL_HITTEST_DRAGGABLE;
-        break;
-      case 2:
-        result = SDL_HITTEST_RESIZE_TOPLEFT;
-        break;
-      case 3:
-        result = SDL_HITTEST_RESIZE_TOP;
-        break;
-      case 4:
-        result = SDL_HITTEST_RESIZE_TOPRIGHT;
-        break;
-      case 5:
-        result = SDL_HITTEST_RESIZE_RIGHT;
-        break;
-      case 6:
-        result = SDL_HITTEST_RESIZE_BOTTOMRIGHT;
-        break;
-      case 7:
-        result = SDL_HITTEST_RESIZE_BOTTOM;
-        break;
-      case 8:
-        result = SDL_HITTEST_RESIZE_BOTTOMLEFT;
-        break;
-      case 9:
-        result = SDL_HITTEST_RESIZE_LEFT;
-        break;
-       default:
-        result = SDL_HITTEST_NORMAL;
-        break;
+  static value *hitTestCallback = NULL;
+  if (hitTestCallback == NULL) {
+    hitTestCallback = caml_named_value("__sdl2_caml_hittest__");
+  }
+  value vWin = (value)win;
+  value vRet = caml_callback3(*hitTestCallback, vWin, Val_int(area->x),
+                              Val_int(area->y));
+  SDL_HitTestResult result;
+  switch (Int_val(vRet)) {
+  case 0:
+    result = SDL_HITTEST_NORMAL;
+    break;
+  case 1:
+    result = SDL_HITTEST_DRAGGABLE;
+    break;
+  case 2:
+    result = SDL_HITTEST_RESIZE_TOPLEFT;
+    break;
+  case 3:
+    result = SDL_HITTEST_RESIZE_TOP;
+    break;
+  case 4:
+    result = SDL_HITTEST_RESIZE_TOPRIGHT;
+    break;
+  case 5:
+    result = SDL_HITTEST_RESIZE_RIGHT;
+    break;
+  case 6:
+    result = SDL_HITTEST_RESIZE_BOTTOMRIGHT;
+    break;
+  case 7:
+    result = SDL_HITTEST_RESIZE_BOTTOM;
+    break;
+  case 8:
+    result = SDL_HITTEST_RESIZE_BOTTOMLEFT;
+    break;
+  case 9:
+    result = SDL_HITTEST_RESIZE_LEFT;
+    break;
+  default:
+    result = SDL_HITTEST_NORMAL;
+    break;
+  }
 
-    }
-
-    return result;
-  };
+  return result;
+};
 
 CAMLprim value resdl_SDL_EnableHitTest(value vWin) {
   SDL_Window *win = (SDL_Window *)vWin;
@@ -149,13 +147,10 @@ CAMLprim value resdl_SDL_SetWin32ProcessDPIAware(value vWin) {
   CAMLparam1(vWin);
 
 #ifdef WIN32
-  SDL_Window *win = (SDL_Window *)vWin;
-  HWND hwnd = getHWNDFromSDLWindow(win);
   void *userDLL;
   BOOL(WINAPI * SetProcessDPIAware)(void); // Vista and later
   void *shcoreDLL;
   HRESULT(WINAPI * SetProcessDpiAwareness)(PROCESS_DPI_AWARENESS dpiAwareness);
-  // Windows 8.1 and later INT(WINAPI *GetScaleFactorForDevice)(int deviceType);
 
   userDLL = SDL_LoadObject("USER32.DLL");
   if (userDLL) {
@@ -177,7 +172,6 @@ CAMLprim value resdl_SDL_SetWin32ProcessDPIAware(value vWin) {
     // Try Vista - Windows 8 version.
     // This has a constant scale factor for all monitors.
     BOOL success = SetProcessDPIAware();
-    SDL_Log("called SetProcessDPIAware: %d", (int)success);
   }
 #endif
 
@@ -206,7 +200,9 @@ CAMLprim value resdl_SDL_GetWin32ScaleFactor(value vWin) {
     int pScale;
     GetScaleFactorForMonitor(hmon, &pScale);
     CAMLreturn(caml_copy_double(pScale / 100.0));
-  };
+  } else {
+    CAMLreturn(caml_copy_double(1.0));
+  }
 
 #else
   CAMLreturn(caml_copy_double(1.0));

--- a/src/sdl2_wrapper.cpp
+++ b/src/sdl2_wrapper.cpp
@@ -514,6 +514,20 @@ CAMLprim value Val_SDL_Event(SDL_Event *event) {
     case SDL_WINDOWEVENT_HIT_TEST:
       v = Val_SDL_WindowEvent(23, event->window.windowID);
       break;
+    case SDL_PANEVENT:
+      v = caml_alloc(1, 24);
+
+      vInner = caml_alloc(8, 0);
+      Store_field(vInner, 0, Val_int(event->window.windowID));
+      Store_field(vInner, 1, Val_int(event->pan.x));
+      Store_field(vInner, 2, Val_int(event->pan.y));
+      Store_field(vInner, 3, Val_bool(event->pan.contains_x));
+      Store_field(vInner, 4, Val_bool(event->pan.contains_y));
+      Store_field(vInner, 5, Val_bool(event->pan.fling));
+      Store_field(vInner, 6, Val_bool(event->pan.interrupt));
+      // verify this is the correct way of representing a ref to some WheelType.t
+      Store_field(vInner, 7, Val_int(event->pan.source_type));
+      break;
     default:
       v = Val_int(1);
     };


### PR DESCRIPTION
Depends on https://github.com/revery-ui/esy-sdl2/pull/6

Adds (once done) smooth scrolling support back into revery (non-kinetic for now.)

This is the second step in integrating https://github.com/szbergeron/libscroll and finishing development of that library; libscroll will provide the kinetic scrolling, event interpolation, and overscroll effects. The original code used for kinetic/smooth scrolling in scrollviews can hopefully be taken from revery for now and hooked up directly here.